### PR TITLE
Remove FullMessageAttachment

### DIFF
--- a/src/features/command.ts
+++ b/src/features/command.ts
@@ -1,8 +1,9 @@
 import { App } from '@slack/bolt'
+import { MessageAttachment } from '@slack/types'
 import { ComposerModal, ComposerModalProps, Disclaimer } from '../blocks'
 import config from '../config'
 import * as utils from '../utils'
-import { ConversationsInfoResult, FullMessageAttachment, UsersInfoResult } from '../utils/slack'
+import { ConversationsInfoResult, UsersInfoResult } from '../utils/slack'
 
 export default (app: App) => {
     app.command('/wolf', async ({ ack, client, command }) => {
@@ -47,21 +48,14 @@ export default (app: App) => {
 
             const signature = ` (Sent via Wolf by <@${body.user.id}>)`
             const ts = new Date(selectedDate).getTime() / 1000 // TODO: Fix dates being off by one day
-            const messageUrl = utils.getUrl(body.team.domain, sourceConversation, ts.toString())
-            const wolfMessage: FullMessageAttachment = {
+            const wolfMessage: MessageAttachment = {
                 author_icon: user.profile.image_48,
-                author_id: user.id,
                 author_link: utils.getAuthorLink(body.team.domain, user.id),
                 author_name: user.profile.display_name || user.profile.real_name,
-                author_subname: user.profile.display_name || user.profile.real_name,
-                channel_id: sourceConversation,
-                channel_name: channel.name,
                 color: 'D0D0D0',
                 fallback: utils.getFallbackText(ts.toString(), user.name, inputMessage) + signature,
                 footer: `${selectedMessageType === 'message' ? 'Posted' : 'From a thread'} in #${channel.name}`,
-                from_url: messageUrl,
                 mrkdwn_in: ['text'],
-                original_url: messageUrl,
                 text: utils.removeSpecialTags(inputMessage),
                 ts: ts.toString(),
             }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,9 +4,6 @@ export const getAuthorLink = (teamDomain: string, userId: string): string =>
 export const getFallbackText = (ts: string, username: string, text: string): string =>
     `[${ts}] ${username}: ${text}`
 
-export const getUrl = (teamDomain: string, channelId: string, messageId: string): string =>
-    `https://${teamDomain}.slack.com/archives/${channelId}/p${messageId}`
-
 // Inserts zero-width non-joiner to prevent special tags like "@everyone" and "<!channel|channel>" from working
 export const removeSpecialTags = (str: string): string => str
     .replace(/@(channel|everyone|here)/ig, '@\u200c$1')

--- a/src/utils/slack.ts
+++ b/src/utils/slack.ts
@@ -1,4 +1,3 @@
-import { MessageAttachment } from '@slack/types'
 import { WebAPICallResult } from '@slack/web-api'
 
 export interface ConversationsInfoResult extends WebAPICallResult {
@@ -7,17 +6,4 @@ export interface ConversationsInfoResult extends WebAPICallResult {
 
 export interface UsersInfoResult extends WebAPICallResult {
     user: any // This is bad
-}
-
-export interface FullMessageAttachment extends MessageAttachment {
-    author_id?: string
-    author_subname?: string
-    channel_id?: string
-    channel_name?: string
-    from_url?: string
-    id?: number
-    is_msg_unfurl?: boolean
-    is_reply_unfurl?: boolean
-    is_share?: boolean
-    original_url?: string
 }


### PR DESCRIPTION
The extra parameters didn't actually do anything because Wolf's message wasn't sent by Slack's `chat.shareMessage` method.